### PR TITLE
Fix/swarinfo 570 unicast dto exchange

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -248,7 +248,6 @@ class BroadcastIPTask : public AbstractTask<10 * configMINIMAL_STACK_SIZE> {
     }
 };
 
-
 void app_main(void) {
     IBSP* bsp = &BspContainer::getBSP();
     bsp->initChip();

--- a/src/message-handler/include/message-handler/NetworkSerializer.h
+++ b/src/message-handler/include/message-handler/NetworkSerializer.h
@@ -3,13 +3,15 @@
 
 #include "INetworkManager.h"
 #include "INetworkOutputStream.h"
+#include "logger/ILogger.h"
 #include "pheromones/HiveMindHostSerializer.h"
 #include "pheromones/IProtobufOutputStream.h"
-#include "logger/ILogger.h"
 
 class NetworkSerializer : public IHiveMindHostSerializer {
   public:
-    NetworkSerializer(INetworkOutputStream& stream, INetworkManager& networkManager, ILogger& logger);
+    NetworkSerializer(INetworkOutputStream& stream,
+                      INetworkManager& networkManager,
+                      ILogger& logger);
     virtual ~NetworkSerializer() = default;
 
     bool serializeToStream(const MessageDTO& message) override;

--- a/src/message-handler/include/message-handler/NetworkSerializer.h
+++ b/src/message-handler/include/message-handler/NetworkSerializer.h
@@ -5,10 +5,11 @@
 #include "INetworkOutputStream.h"
 #include "pheromones/HiveMindHostSerializer.h"
 #include "pheromones/IProtobufOutputStream.h"
+#include "logger/ILogger.h"
 
 class NetworkSerializer : public IHiveMindHostSerializer {
   public:
-    NetworkSerializer(INetworkOutputStream& stream, INetworkManager& networkManager);
+    NetworkSerializer(INetworkOutputStream& stream, INetworkManager& networkManager, ILogger& logger);
     virtual ~NetworkSerializer() = default;
 
     bool serializeToStream(const MessageDTO& message) override;
@@ -17,6 +18,7 @@ class NetworkSerializer : public IHiveMindHostSerializer {
     INetworkOutputStream& m_outputStream;
     INetworkManager& m_networkManager;
     HiveMindHostSerializer m_hivemindHostSerializer;
+    ILogger& m_logger;
 };
 
 #endif // HIVE_CONNECT_NETWORKSERIALIZER_H

--- a/src/message-handler/src/MessageDispatcher.cpp
+++ b/src/message-handler/src/MessageDispatcher.cpp
@@ -24,10 +24,6 @@ MessageDispatcher::MessageDispatcher(
 bool MessageDispatcher::deserializeAndDispatch() {
     MessageDTO message;
     if (m_deserializer.deserializeFromStream(message)) {
-        // TO REMOVE
-        if (const auto* testResponse = std::get_if<ResponseDTO>(&message.getMessage())) {
-            m_logger.log(LogLevel::Info, "Received response!");
-        }
         // Handle greet
         if (const auto* greeting = std::get_if<GreetingDTO>(&message.getMessage())) {
             m_logger.log(LogLevel::Info, "Received greeting, ID obtained is %d", greeting->getId());

--- a/src/message-handler/src/MessageDispatcher.cpp
+++ b/src/message-handler/src/MessageDispatcher.cpp
@@ -24,6 +24,10 @@ MessageDispatcher::MessageDispatcher(
 bool MessageDispatcher::deserializeAndDispatch() {
     MessageDTO message;
     if (m_deserializer.deserializeFromStream(message)) {
+        // TO REMOVE
+        if (const auto* testResponse = std::get_if<ResponseDTO>(&message.getMessage())) {
+            m_logger.log(LogLevel::Info, "Received response!");
+        }
         // Handle greet
         if (const auto* greeting = std::get_if<GreetingDTO>(&message.getMessage())) {
             m_logger.log(LogLevel::Info, "Received greeting, ID obtained is %d", greeting->getId());

--- a/src/message-handler/src/NetworkSerializer.cpp
+++ b/src/message-handler/src/NetworkSerializer.cpp
@@ -1,8 +1,13 @@
 #include "NetworkSerializer.h"
 #include <pb_encode.h>
 
-NetworkSerializer::NetworkSerializer(INetworkOutputStream& stream, INetworkManager& manager, ILogger& logger) :
-    m_outputStream(stream), m_networkManager(manager), m_hivemindHostSerializer(stream), m_logger(logger) {}
+NetworkSerializer::NetworkSerializer(INetworkOutputStream& stream,
+                                     INetworkManager& manager,
+                                     ILogger& logger) :
+    m_outputStream(stream),
+    m_networkManager(manager),
+    m_hivemindHostSerializer(stream),
+    m_logger(logger) {}
 
 bool NetworkSerializer::serializeToStream(const MessageDTO& message) {
     Message msg;

--- a/src/message-handler/src/NetworkSerializer.cpp
+++ b/src/message-handler/src/NetworkSerializer.cpp
@@ -20,13 +20,6 @@ bool NetworkSerializer::serializeToStream(const MessageDTO& message) {
     }
 
     bool ret = m_hivemindHostSerializer.serializeToStream(message);
-    // TO REMOVE
-    if (ret) {
-        m_logger.log(LogLevel::Info, "Successfully sent message");
-    } else
-    {
-        m_logger.log(LogLevel::Info, "Failed to send message");
-    }
     m_outputStream.close();
     return ret;
 }

--- a/src/message-handler/src/NetworkSerializer.cpp
+++ b/src/message-handler/src/NetworkSerializer.cpp
@@ -1,8 +1,8 @@
 #include "NetworkSerializer.h"
 #include <pb_encode.h>
 
-NetworkSerializer::NetworkSerializer(INetworkOutputStream& stream, INetworkManager& manager) :
-    m_outputStream(stream), m_networkManager(manager), m_hivemindHostSerializer(stream) {}
+NetworkSerializer::NetworkSerializer(INetworkOutputStream& stream, INetworkManager& manager, ILogger& logger) :
+    m_outputStream(stream), m_networkManager(manager), m_hivemindHostSerializer(stream), m_logger(logger) {}
 
 bool NetworkSerializer::serializeToStream(const MessageDTO& message) {
     Message msg;
@@ -10,14 +10,23 @@ bool NetworkSerializer::serializeToStream(const MessageDTO& message) {
 
     auto ip = m_networkManager.getIPFromAgentID(message.getDestinationId());
     if (!ip.has_value()) {
+        m_logger.log(LogLevel::Error, "Could not get IP from destination");
         return false;
     }
 
     if (!m_outputStream.setDestination(ip.value())) {
+        m_logger.log(LogLevel::Error, "Could not set destination from IP");
         return false;
     }
 
     bool ret = m_hivemindHostSerializer.serializeToStream(message);
+    // TO REMOVE
+    if (ret) {
+        m_logger.log(LogLevel::Info, "Successfully sent message");
+    } else
+    {
+        m_logger.log(LogLevel::Info, "Failed to send message");
+    }
     m_outputStream.close();
     return ret;
 }

--- a/src/message-handler/tests/NetworkSerializerAndDeserializerIntegrationTests.cpp
+++ b/src/message-handler/tests/NetworkSerializerAndDeserializerIntegrationTests.cpp
@@ -20,7 +20,7 @@ class NetworkSerializerAndDeserializerIntegrationTestsFixture : public testing::
         m_inputStream = new NetworkInputStream(m_logger, 9000);
         m_outputStream = new NetworkOutputStream(m_logger);
 
-        m_serializer = new NetworkSerializer(*m_outputStream, m_networkManager);
+        m_serializer = new NetworkSerializer(*m_outputStream, m_networkManager, m_logger);
         m_deserializer = new NetworkDeserializer(*m_inputStream);
     }
 

--- a/src/network/src/esp/src/TCPServer.cpp
+++ b/src/network/src/esp/src/TCPServer.cpp
@@ -41,7 +41,7 @@ bool TCPServer::receive(uint8_t* data, uint16_t length) {
 
     if (receivedBytes < 0) {
         m_logger.log(LogLevel::Error, "Failed to read data from fresh connection");
-        closesocket(m_clientSocket);
+        lwip_close(m_clientSocket);
         m_clientSocket = NO_SOCKET;
         return false;
     }
@@ -55,7 +55,7 @@ bool TCPServer::receive(uint8_t* data, uint16_t length) {
             // transmitting, lwip_rcv will return 0. When the client disconnects, lwip_rcv will
             // return -1.
             m_logger.log(LogLevel::Info, "Client terminated connection");
-            closesocket(m_clientSocket);
+            lwip_close(m_clientSocket);
             m_clientSocket = NO_SOCKET;
             break;
         }
@@ -68,8 +68,8 @@ bool TCPServer::receive(uint8_t* data, uint16_t length) {
 bool TCPServer::isReady() { return m_acceptingSocket != NO_SOCKET; }
 
 void TCPServer::closeCurrentClient() {
-    if (m_clientSocket < 0) {
-        close(m_clientSocket);
+    if (m_clientSocket > 0) {
+        lwip_close(m_clientSocket);
     }
     m_clientSocket = -1;
 }

--- a/src/network/src/esp/src/TCPServer.cpp
+++ b/src/network/src/esp/src/TCPServer.cpp
@@ -41,7 +41,7 @@ bool TCPServer::receive(uint8_t* data, uint16_t length) {
 
     if (receivedBytes < 0) {
         m_logger.log(LogLevel::Error, "Failed to read data from fresh connection");
-        lwip_close(m_clientSocket);
+        closesocket(m_clientSocket);
         m_clientSocket = NO_SOCKET;
         return false;
     }
@@ -55,7 +55,7 @@ bool TCPServer::receive(uint8_t* data, uint16_t length) {
             // transmitting, lwip_rcv will return 0. When the client disconnects, lwip_rcv will
             // return -1.
             m_logger.log(LogLevel::Info, "Client terminated connection");
-            lwip_close(m_clientSocket);
+            closesocket(m_clientSocket);
             m_clientSocket = NO_SOCKET;
             break;
         }
@@ -69,7 +69,7 @@ bool TCPServer::isReady() { return m_acceptingSocket != NO_SOCKET; }
 
 void TCPServer::closeCurrentClient() {
     if (m_clientSocket > 0) {
-        lwip_close(m_clientSocket);
+        closesocket(m_clientSocket);
     }
     m_clientSocket = -1;
 }

--- a/src/network/src/esp/src/TCPServer.cpp
+++ b/src/network/src/esp/src/TCPServer.cpp
@@ -46,7 +46,7 @@ bool TCPServer::receive(uint8_t* data, uint16_t length) {
         return false;
     }
 
-    while (receivedBytes <= length) {
+    while (receivedBytes < length) {
         ssize_t nbytes =
             lwip_recv(m_clientSocket, data + receivedBytes, (length - receivedBytes), 0);
 


### PR DESCRIPTION
Fixes for working DTO exchange on the network:

- Reworked task priority to give priority to internal network tasks
- Fixed comparison operators for socket and number of bytes
- Used thread-safe function `closesocket` instead of `close`

Also added logs to debug socket creation to send messages